### PR TITLE
Supported Platform.sh provided environmental vars, fixes #82

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ This repository is used with `ddev get platformsh/ddev-platformsh` to get a rich
     * Redis
     * Memcached
     * ElasticSearch
+* Provides the following [Platform.sh-provided environmental variables](https://docs.platform.sh/development/variables/use-variables.html#use-platformsh-provided-variables): 
+  * PLATFORM_APP_DIR
+  * PLATFORM_APPLICATION_NAME
+  * PLATFORM_CACHE_DIR
+  * PLATFORM_ENVIRONMENT
+  * PLATFORM_PROJECT
+  * PLATFORM_PROJECT_ENTROPY
+  * PLATFORM_RELATIONSHIPS
+  * PLATFORM_ROUTES (see note below)
+  * PLATFORM_TREE_ID
+  * PLATFORM_VARIABLES
+
+DDEV does not currently parse the contents of `.platform/routes.yaml` and therefore, `PLATFORM_ROUTES` only contains information related to a single, default route.
 
 ## What has been tested
 


### PR DESCRIPTION
Closes #82 
Adds a list of [Platform-provided environmental variables](https://docs.platform.sh/development/variables/use-variables.html#use-platformsh-provided-variables) that are currently supported in DDEV.

List of variables that are "missing" or not yet implemented:
* PLATFORM_APPLICATION
* PLATFORM_BRANCH
* PLATFORM_DOCUMENT_ROOT
* PLATFORM_ENVIRONMENT_TYPE
* PLATFORM_OUTPUT_DIR
* PLATFORM_SMTP_HOST
* PLATFORM_SOURCE_DIR
* PORT - not always available 
* SOCKET

There are two `PLATFORM_*` environmental variables in DDEV that do not map to ones we provide. 
* PLATFORM_DIR - is this possibly supposed to be `PLATFORM_DOCUMENT_ROOT` that is "missing"?
* PLATFORM_MOUNTS
